### PR TITLE
providers/okta: filter group query output

### DIFF
--- a/providers/okta/okta.go
+++ b/providers/okta/okta.go
@@ -84,7 +84,7 @@ func (c *Client) GroupByName(ctx context.Context, groupName string) (*okta.Group
 	}
 
 	for _, group := range oktaGroups {
-		if *group.Profile.Name == groupName {
+		if group.Profile != nil && group.Profile.Name != nil && *group.Profile.Name == groupName {
 			return &group, nil
 		}
 	}

--- a/providers/okta/okta.go
+++ b/providers/okta/okta.go
@@ -83,11 +83,13 @@ func (c *Client) GroupByName(ctx context.Context, groupName string) (*okta.Group
 		return nil, fmt.Errorf("failed to query okta group: %w", err)
 	}
 
-	// okta group names are unique
-	if len(oktaGroups) != 1 {
-		return nil, fmt.Errorf("unable to find okta group %q", groupName)
+	for _, group := range oktaGroups {
+		if *group.Profile.Name == groupName {
+			return &group, nil
+		}
 	}
-	return &oktaGroups[0], nil
+
+	return nil, fmt.Errorf("unable to find okta group %q", groupName)
 }
 
 func jwkFromBytes(bytes []byte) (*jose.JSONWebKey, error) {


### PR DESCRIPTION
The query option (`Q`) when listing groups is not an exact search, but instead returns all groups that match. If the group being searched for contains part of the name of another then multiple results will be returned from the API call. This change iterates over the results and discards ones that aren't a direct match.