### PR TITLE
istio stop hook defer function

### DIFF
--- a/httputils/istio/stophook.go
+++ b/httputils/istio/stophook.go
@@ -9,7 +9,7 @@ import (
 // It is intended to be used as a defer function
 func StopHook(timeout int) {
 	c := &http.Client{
-		Timeout: time.Duration(timeout) * time.Milisecond,
+		Timeout: time.Duration(timeout) * time.Millisecond,
 	}
 	r, _ := http.NewRequest("POST", "http://localhost:15000/quitquitquit", nil)
 	c.Do(r) //nolint

--- a/httputils/istio/stophook.go
+++ b/httputils/istio/stophook.go
@@ -1,0 +1,16 @@
+package istio
+
+import (
+	"net/http"
+	"time"
+)
+
+// StopHook takes a timeout in milliseconds and sends a request to istio's stop hook.
+// It is intended to be used as a defer function
+func StopHook(timeout int) {
+	c := &http.Client{
+		Timeout: time.Duration(timeout) * time.Milisecond,
+	}
+	r, _ := http.NewRequest("POST", "http://localhost:15000/quitquitquit", nil)
+	c.Do(r)
+}

--- a/httputils/istio/stophook.go
+++ b/httputils/istio/stophook.go
@@ -12,5 +12,5 @@ func StopHook(timeout int) {
 		Timeout: time.Duration(timeout) * time.Milisecond,
 	}
 	r, _ := http.NewRequest("POST", "http://localhost:15000/quitquitquit", nil)
-	c.Do(r)
+	c.Do(r) //nolint
 }


### PR DESCRIPTION
This adds a function for use with defer to ensure an istio proxy stops when a main process stops. 