### PR TITLE
cli: cobra TimeFlag type

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -7,11 +7,11 @@ import (
 type TimeFlag time.Time
 
 func (t *TimeFlag) String() string {
-	return time.Time(*t).Format(time.RFC3339)
+	return time.Time(*t).Format(time.RFC3339Nano)
 }
 
 func (t *TimeFlag) Set(value string) error {
-	parsedTime, err := time.Parse(time.RFC3339, value)
+	parsedTime, err := time.Parse(time.RFC3339Nano, value)
 	if err != nil {
 		return err
 	}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"time"
+)
+
+type TimeFlag time.Time
+
+func (t *TimeFlag) String() string {
+	return time.Time(*t).Format(time.RFC3339)
+}
+
+func (t *TimeFlag) Set(value string) error {
+	parsedTime, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return err
+	}
+	*t = TimeFlag(parsedTime)
+	return nil
+}
+
+func (t *TimeFlag) Type() string {
+	return "time"
+}
+
+func (t TimeFlag) Time() time.Time {
+	return time.Time(t)
+}

--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -1,0 +1,76 @@
+package cli_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kanopy-platform/go-library/cli"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeFlag_Time(t *testing.T) {
+	expectedTime := time.Date(1970, 12, 25, 15, 30, 45, 0, time.UTC)
+	tf := cli.TimeFlag(expectedTime)
+
+	result := tf.Time()
+	assert.True(t, result.Equal(expectedTime),
+		"Time() = %v, want %v", result, expectedTime)
+}
+
+func TestTimeFlag_WithPflag(t *testing.T) {
+	tests := []struct {
+		name      string
+		flagValue string
+		wantErr   bool
+		expected  time.Time
+	}{
+		{
+			name:      "valid",
+			flagValue: "1970-12-25T15:30:45Z",
+			wantErr:   false,
+			expected : time.Date(1970, 12, 25, 15, 30, 45, 0, time.UTC),
+		},
+		{
+			name:      "invalid",
+			flagValue: "invalid-time",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+			var timeFlag cli.TimeFlag
+
+			fs.VarP(&timeFlag, "time", "t", "time flag for testing")
+
+			args := []string{"--time", tt.flagValue}
+			err := fs.Parse(args)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, timeFlag.Time())
+		})
+	}
+}
+
+func TestTimeFlag_RoundTrip(t *testing.T) {
+	// test that String() and Set() are consistent
+	originalTime := time.Date(1970, 12, 25, 15, 30, 45, 123456789, time.UTC)
+	tf1 := cli.TimeFlag(originalTime)
+
+	str := tf1.String()
+
+	var tf2 cli.TimeFlag
+	err := tf2.Set(str)
+	assert.NoError(t, err)
+
+	assert.True(t, tf1.Time().Equal(tf2.Time()),
+		"Round trip failed: original = %v, result = %v", tf1.Time(), tf2.Time())
+}


### PR DESCRIPTION
Provides a cobra flag type that will enforce that a provided value is an RFC3339 timestamp